### PR TITLE
Fixed broken key index wrap-around

### DIFF
--- a/firmware/ESP32/src/openhaystack_main.c
+++ b/firmware/ESP32/src/openhaystack_main.c
@@ -223,7 +223,7 @@ void app_main(void)
         if (cycle >= REUSE_CYCLES)
         {
             ESP_LOGI(LOG_TAG, "Max cycles %d are reached. Changing key ", cycle);
-            key_index = (key_index + 1) % (key_count + 1); // Back to zero if out of range
+            key_index = (key_index + 1) % key_count; // Back to zero if out of range
             cycle = 0;
         }
         else


### PR DESCRIPTION
Hi,

The key-index wrapping mechanism was broken.

The statement was:
key_index = (key_index + 1) % (key_count + 1);

Which meant that for key_count = N values (0..N-1) were valid.
For example: key_count == 1 would make key_index values 0 AND 1, which obviously is not valid.
The read is then attempted beyond available keys. In case of an empty memory it would pull key consisting of all 0xFFs.

The fix is to remove +1 from the right side of the modulo operator.

Cheers,
Bartosz



