### PR TITLE
Add datePublished to location reports

### DIFF
--- a/endpoint/mh_endpoint.py
+++ b/endpoint/mh_endpoint.py
@@ -111,6 +111,9 @@ class ServerHandler(BaseHTTPRequestHandler):
                 data = base64.b64decode(entry['payload'])
                 timestamp = int.from_bytes(data[0:4], 'big') + 978307200
                 if (timestamp > startdate):
+                    # Only add datePublished if Apple does not return the key
+                    if not entry.get("datePublished"):
+                        entry["datePublished"] = timestamp
                     newResults[timestamp] = entry
 
             sorted_map = OrderedDict(sorted(newResults.items(), reverse=True))


### PR DESCRIPTION
A couple days ago Apple stopped returning the `datePublished` from `gateway.icloud.com/acsnservice/fetch`. This is the current response:
```
{"results":[{"payload":"L2HBAA=","description":"found","id":"sAufoi8PJY=","statusCode":0}],"statusCode":"200"}
```
This breaks the client when parsing the json:

https://github.com/dchristl/macless-haystack/blob/f847f2ef3297d3e69ad89dc604bdd84f5dacb81d/macless_haystack/lib/findMy/find_my_controller.dart#L70-L71

`datePublished` returned from the original request still take precedence if Apple is doing A/B testing.

Same issue reported https://github.com/biemster/FindMy/issues/94#issue-4075089557

