### PR TITLE
Add ESP32-S3 build support

### DIFF
--- a/firmware/ESP32/platformio.ini
+++ b/firmware/ESP32/platformio.ini
@@ -16,3 +16,10 @@ monitor_speed = 115200
 board_build.partitions = with_key.csv
 
 
+
+[env:esp32s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = espidf
+monitor_speed = 115200
+board_build.partitions = with_key.csv

--- a/firmware/ESP32/sdkconfig.defaults
+++ b/firmware/ESP32/sdkconfig.defaults
@@ -1,0 +1,9 @@
+# ESP32-S3 needs these enabled explicitly (the original ESP32 has them on by default):
+# - legacy BLE 4.2 advertising API used by the firmware
+# - 4MB flash so with_key.csv's key partition (ends at 0x210000) fits
+CONFIG_BT_ENABLED=y
+CONFIG_BT_BLUEDROID_ENABLED=y
+CONFIG_BT_BLE_ENABLED=y
+CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
+CONFIG_BT_BLE_50_FEATURES_SUPPORTED=y
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION
## What

Adds an `esp32s3` PlatformIO env so the firmware builds for the **ESP32-S3**, which currently has no prebuilt binary or build config (only the original ESP32 / nRF are shipped).

## Why it needs more than a new board line

The S3 (Xtensa LX7) differs from the original ESP32 (LX6) and won't build cleanly with defaults:

- **`CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y`** — the firmware uses the legacy BLE 4.2 advertising API (`esp_ble_gap_start_advertising` / `esp_ble_gap_config_adv_data_raw` / `esp_ble_gap_stop_advertising`). The S3 doesn't compile these in by default (the original ESP32 does), so linking fails with `undefined reference` without it.
- **`CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y`** — `with_key.csv`'s key partition ends at `0x210000` (~2.06 MB), which overflows the default 2 MB flash size.

`esp32dev` is untouched — it keeps using its existing `sdkconfig.esp32dev`, so this only affects the new S3 env.

## Tested

Built with PlatformIO and flashed to an ESP32-S3 (rev v0.2, 16 MB flash); it advertises and gets located on the Find My network. Note the S3 bootloader flashes at `0x0` (not `0x1000`).

Prebuilt S3 binaries + a full flashing guide (download mode, offsets, gotchas) here: https://github.com/jichaowang02-lang/macless-haystack-esp32s3
